### PR TITLE
fix getting the python current version

### DIFF
--- a/python-install
+++ b/python-install
@@ -34,7 +34,7 @@ if [ ! -d ./var/python-build ]; then
 fi
 
 if [ "x"$FLAG_FORCE = "x" -a -d "$LOCATION" -a -x "$LOCATION/bin/python" ]; then
-    current_ver=$("$LOCATION"/bin/python --version)
+    current_ver=$("$LOCATION"/bin/python --version  2>&1 )
     if [ "x$current_ver" = "xPython $TARGET_VERSION" ]; then
         echo "python $TARGET_VERSION already installed on $LOCATION"
         echo "To do force re-install, use '-f' option"


### PR DESCRIPTION
Since python --version output is a stderr not a stdin, the redirect is required.
