### PR TITLE
Change URL of github content domains

### DIFF
--- a/perl-install
+++ b/perl-install
@@ -25,7 +25,7 @@ cd $(dirname $0)
 set -e
 mkdir -p ./bin
 curl -s https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build > ./bin/perl-build
-curl -s -L http://cpanmin.us/ > ./bin/fatpack_cpanm
+curl -s --sslv3 -L http://cpanmin.us/ > ./bin/fatpack_cpanm
 set +e
 
 if [ "x"$FLAG_FORCE = "x" -a -d "$LOCATION" -a -x "$LOCATION/bin/perl" ]; then


### PR DESCRIPTION
GitHub has changed URL of content domains.
- before: raw.github.com
- after: raw.githubusercontent.com

see: [New user content domains](https://developer.github.com/changes/2014-04-25-user-content-security/)

And perl-install with OLD-versioned curl (7.19.7 in CentOS 6.5) fails because
SSL/TLS version probably is old.

This issue causes `curl -L http://cpanmin.us/` returns 400 Bad Request
when redirecting raw.github.com to raw.githubusercontent.com.

``` console
$ curl -s -IL http://cpanmin.us/
HTTP/1.1 302 Found
Server: nginx/1.2.7
Date: Sun, 27 Apr 2014 05:23:30 GMT
Content-Type: text/html; charset=iso-8859-1
Connection: keep-alive
Location: https://raw.github.com/miyagawa/cpanminus/master/cpanm

HTTP/1.1 301 Moved Permanently
Date: Sun, 27 Apr 2014 05:23:31 GMT
Server: Apache
Location: https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm
Accept-Ranges: bytes
Via: 1.1 varnish
Age: 0
X-Served-By: cache-ty68-TYO
X-Cache: MISS
X-Cache-Hits: 0
Vary: Accept-Encoding

HTTP/1.1 400 Bad Request
Date: Sun, 27 Apr 2014 05:23:31 GMT
Server: Apache
Connection: close
Content-Type: text/html; charset=iso-8859-1
```

Using SSLv3 avoids this failure.
