### PR TITLE
Calling "exit" in a subshell won't work.

### DIFF
--- a/php-install
+++ b/php-install
@@ -31,7 +31,8 @@ if [ ! -d ./var/php-build ]; then
         git clone -q git://github.com/CHH/php-build.git php-build-repo
         cd php-build-repo
         PREFIX="$XBUILD_PATH"/var/php-build ./install.sh >/dev/null 2>&1
-    ) || (echo "failed to download php-build" && exit 1)
+    )
+    if [ 0 != "$?" ]; then echo "failed to download php-build" ; exit 1; fi
 fi
 
 if [ "x"$FLAG_FORCE = "x" -a -d "$LOCATION" -a -x "$LOCATION/bin/php" ]; then

--- a/python-install
+++ b/python-install
@@ -30,7 +30,8 @@ if [ ! -d ./var/python-build ]; then
         git clone -q https://github.com/yyuu/pyenv.git pyenv-repo
         cd pyenv-repo/plugins/python-build
         PREFIX="$XBUILD_PATH"/var/python-build ./install.sh >/dev/null 2>&1
-    ) || (echo "failed to download python-build" && exit 1)
+    )
+    if [ 0 != "$?" ]; then echo "failed to download python-build"; exit 1; fi
 fi
 
 if [ "x"$FLAG_FORCE = "x" -a -d "$LOCATION" -a -x "$LOCATION/bin/python" ]; then

--- a/ruby-install
+++ b/ruby-install
@@ -34,7 +34,8 @@ if [ ! -f ./var/ruby-build.date -o "x"$oldcheck = "x" ]; then
         touch ruby-build.date
         cd ruby-build-repo
         PREFIX="$XBUILD_PATH"/var/ruby-build ./install.sh >/dev/null 2>&1
-    ) || (echo "failed to download ruby-build" && exit 1)
+    )
+    if [ 0 != "$?" ]; then echo "failed to download ruby-build"; exit 1; fi
 fi
 rm -f ./var/.24hours
 
@@ -70,7 +71,8 @@ fi
         gems="bundler $gems"
     fi
     "$LOCATION"/bin/gem install --no-rdoc --no-ri $gems > /tmp/$USER-ruby-install-bundler.log 2>&1
-) || (echo "gem install failed. see log /tmp/$USER-ruby-install-bundler.log" && exit 2)
+)
+if [ 0 != "$?" ]; then echo "gem install failed. see log /tmp/$USER-ruby-install-bundler.log"; exit 2; fi
 
 echo "ruby $TARGET_VERSION successfully installed on $LOCATION"
 echo "To use this ruby, do 'export PATH=$LOCATION/bin:\$PATH'."


### PR DESCRIPTION
This is almost nitpicking...

```
08/06 20:16 [nodakai@kaidev01] /tmp/xbuild$ bash
nodakai@kaidev01:/tmp/xbuild$ ( cd /foobar ) || ( echo NG; exit 1 )
bash: cd: /foobar: そのようなファイルやディレクトリはありません
NG
nodakai@kaidev01:/tmp/xbuild$ if ! ( cd /foobar ); then echo NG; exit 1; fi
bash: cd: /foobar: そのようなファイルやディレクトリはありません
NG
exit
08/06 20:16 [nodakai@kaidev01] /tmp/xbuild$
```

The shortest fix would have been changing  `( ... )` to `{ ... }`.
However curly-braces of Bash _sometimes_ fork a subshell and are too confusing for this purpose.
(cf. http://unix.stackexchange.com/questions/127334/bash-subshell-creation-with-curly-braces )
