### PR TITLE
fix SSLv3 POODLE

### DIFF
--- a/perl-install
+++ b/perl-install
@@ -25,7 +25,7 @@ cd $(dirname $0)
 set -e
 mkdir -p ./bin
 curl -s https://raw.githubusercontent.com/tokuhirom/Perl-Build/master/perl-build > ./bin/perl-build
-curl -s --sslv3 -L http://cpanmin.us/ > ./bin/fatpack_cpanm
+curl -s -L http://cpanmin.us/ > ./bin/fatpack_cpanm
 set +e
 
 if [ "x"$FLAG_FORCE = "x" -a -d "$LOCATION" -a -x "$LOCATION/bin/perl" ]; then


### PR DESCRIPTION
I can't build perl.

can't receive contents from redirect to https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm
with --sslv3 option.

maybe this is SSLv3 POODLE problem.
