### PR TITLE
Support go

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Supports:
 * Node.js
 * PHP
 * Python
+* Go
 
 ## How to install
 
@@ -32,6 +33,10 @@ Install PHP (ex: 5.5.10)
 Install Python (ex: 2.7.6)
 
     xbuild/python-install 2.7.6 ~/local/python-2.7.6
+
+Install Go (ex: 1.3.3)
+
+    xbuild/go-install 1.3.3 ~/local/go-1.3.3
 
 To update minor version, overwrite simply.
 
@@ -80,6 +85,11 @@ Include installed `bin/` to PATH:
     # python
     export PATH=$HOME/local/python-2.7.6/bin:$PATH
     pip install -r requirements.txt
+
+    # go
+    export GOROOT=$HOME/local/go-1.3.3
+    export PATH=$GOROOT/bin:$PATH
+    go version
 
 ## How to try with Docker
 

--- a/go-install
+++ b/go-install
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+while getopts fh OPT
+do
+  case $OPT in
+    "f") FLAG_FORCE="TRUE" ;;
+    "h") FLAG_HELP="TRUE" ;;
+    * ) FLAG_HELP="TRUE" ;;
+  esac
+done
+shift `expr $OPTIND - 1`
+
+TARGET_VERSION="$1"
+LOCATION="$2"
+OS="$3"
+ARCH="$4"
+
+if [ "x"$FLAG_HELP != "x" -o "x$LOCATION" = "x" ]; then
+  echo "[usage] go-install [-f] VERSION LOCATION"
+  echo "  ex: go-install 1.3.3 ~/local/go-1.3.3"
+  echo "  ex: go-install 1.3.3 ~/local/go-1.3.3 linux amd64"
+  echo "  default os is 'linux'"
+  echo "  default arch is 'amd64'"
+  exit 0
+fi
+
+if [ "x$OS" = "x" ]; then
+  OS="linux"
+fi
+
+if [ "x$ARCH" = "x" ]; then
+  ARCH="amd64"
+fi
+
+cd $(dirname $0)
+
+if [ "x"$FLAG_FORCE = "x" -a -d "$LOCATION" -a -x "$LOCATION/bin/go" ]; then
+  current_ver=$("$LOCATION"/bin/go version)
+  expected_ver="$TARGET_VERSION $OS/$ARCH"
+  hit=$(echo $current_ver | grep "$expected_ver")
+  if [ "x$hit" != "x" ]; then
+    echo "go $TARGET_VERSION already installed on $LOCATION"
+    echo "To do force re-install, use '-f' option"
+    exit 0
+  fi
+fi
+
+ARCHIVE_FILENAME="go$TARGET_VERSION.$OS-$ARCH.tar.gz"
+DL_GOLANG_ORG="https://storage.googleapis.com/golang"
+
+echo "Start to install go $TARGET_VERSION ..."
+
+set -e
+
+mkdir -p $LOCATION
+
+curl -s $DL_GOLANG_ORG/$ARCHIVE_FILENAME | tar -C $LOCATION -xzf -
+cp -a $LOCATION/go/* $LOCATION/
+rm -rf $LOCATION/go
+
+echo "go $TARGET_VERSION successfully installed on $LOCATION"
+echo "To use this go, do 'export PATH=$LOCATION/bin:\$PATH' and 'export GOROOT=$LOCATION'."


### PR DESCRIPTION
Simply usage:

```
$ go-install 1.3.3 ~/local/go
```

With OS and ARCH options:

```
$ go-install 1.3.3 ~/local/go linux amd64
```

Testing:

``` shell
$ docker build -t xbuild .
$ docker run --rm -i -t xbuild /bin/bash
$ go-install 1.3.3 /usr/local/go
go 1.3.3 successfully installed on /usr/local/go
To use this go, do 'export PATH=/usr/local/go/bin:$PATH' and 'export GOROOT=/usr/local/go'.
$ export PATH=/usr/local/go/bin:$PATH
$ export GOROOT=/usr/local/go
$ go version
 version go1.3.3 linux/amd64
$ go-install 1.3.3 /usr/local/go
go 1.3.3 already installed on /usr/local/go
To do force re-install, use '-f' option
$ go-install 1.2.2 /usr/local/go
Start to install go 1.2.2 ...
go 1.2.2 successfully installed on /usr/local/go
To use this go, do 'export PATH=/usr/local/go/bin:$PATH' and 'export GOROOT=/usr/local/go'.
$ go version
go version go1.2.2 linux/amd64
```
