### PR TITLE
Add support to io.js

### DIFF
--- a/node-install
+++ b/node-install
@@ -19,6 +19,11 @@ if [ "x"$FLAG_HELP != "x" -o "x$LOCATION" = "x" ]; then
     echo "  ex: node-install v0.10.26 ~/local/node-v0.10"
     echo "  ex: node-install v0.10.26 ~/local/node-v0.10 darwin-x86"
     echo "  default arch is 'linux-x64'"
+    echo ""
+    echo "  for io.js:"
+    echo "  ex: node-install iojs-v1.2.0 ~/local/iojs-v.1.2.0"
+    echo "  ex: node-install iojs-v1.2.0 ~/local/iojs-v.1.2.0 darwin-x64"
+
     exit 0
 fi
 
@@ -37,13 +42,22 @@ if [ "x"$FLAG_FORCE = "x" -a -d "$LOCATION" -a -x "$LOCATION/bin/node" ]; then
     fi
 fi
 
-ARCHIVE_FILENAME="node-$TARGET_VERSION-$ARCH.tar.gz"
-ARCHIVE_DIRNAME="node-$TARGET_VERSION-$ARCH"
+if [ "${TARGET_VERSION:0:5}" == "iojs-" ]; then
+    IOJS_TARGET_VERSION="${TARGET_VERSION#iojs-}"
+
+    ARCHIVE_FILENAME="iojs-$IOJS_TARGET_VERSION-$ARCH.tar.gz"
+    ARCHIVE_DIRNAME="iojs-$IOJS_TARGET_VERSION-$ARCH"
+    ARCHIVE_URL="https://iojs.org/dist/$IOJS_TARGET_VERSION/$ARCHIVE_FILENAME"
+else
+    ARCHIVE_FILENAME="node-$TARGET_VERSION-$ARCH.tar.gz"
+    ARCHIVE_DIRNAME="node-$TARGET_VERSION-$ARCH"
+    ARCHIVE_URL="http://nodejs.org/dist/$TARGET_VERSION/$ARCHIVE_FILENAME"
+fi
 
 set -e
 mkdir -p var/node-archive
 cd var/node-archive
-curl -s -O http://nodejs.org/dist/"$TARGET_VERSION"/"$ARCHIVE_FILENAME"
+curl -s -O $ARCHIVE_URL
 
 cd ..
 tar xzf node-archive/"$ARCHIVE_FILENAME"


### PR DESCRIPTION
```
$ bash -x ./node-install iojs-v1.2.0 ~/opt/iojs-1.2.0 darwin-x64
+ getopts fh OPT
++ expr 1 - 1
+ shift 0
+ TARGET_VERSION=iojs-v1.2.0
+ LOCATION=/Users/harukasan/opt/iojs-1.2.0
+ ARCH=darwin-x64
+ '[' x '!=' x -o x/Users/harukasan/opt/iojs-1.2.0 = x ']'
+ '[' xdarwin-x64 = x ']'
++ dirname ./node-install
+ cd .
+ '[' x = x -a -d /Users/harukasan/opt/iojs-1.2.0 -a -x /Users/harukasan/opt/iojs-1.2.0/bin/node ']'
++ /Users/harukasan/opt/iojs-1.2.0/bin/node -v
+ current_ver=v1.2.0
+ '[' xv1.2.0 = xiojs-v1.2.0 ']'
+ '[' iojs- == iojs- ']'
+ IOJS_TARGET_VERSION=v1.2.0
+ ARCHIVE_FILENAME=iojs-v1.2.0-darwin-x64.tar.gz
+ ARCHIVE_DIRNAME=iojs-v1.2.0-darwin-x64
+ ARCHIVE_URL=https://iojs.org/dist/v1.2.0/iojs-v1.2.0-darwin-x64.tar.gz
+ set -e
+ mkdir -p var/node-archive
+ cd var/node-archive
+ curl -s -O https://iojs.org/dist/v1.2.0/iojs-v1.2.0-darwin-x64.tar.gz
+ cd ..
+ tar xzf node-archive/iojs-v1.2.0-darwin-x64.tar.gz
+ '[' -d /Users/harukasan/opt/iojs-1.2.0 ']'
+ [[ -d /Users/harukasan/opt/iojs-1.2.0.replaced ]]
+ mv /Users/harukasan/opt/iojs-1.2.0 /Users/harukasan/opt/iojs-1.2.0.replaced
+ mv iojs-v1.2.0-darwin-x64 /Users/harukasan/opt/iojs-1.2.0
+ /Users/harukasan/opt/iojs-1.2.0/bin/npm install -g node-gyp
+ '[' 0 -ne 0 ']'
+ echo 'node iojs-v1.2.0 successfully installed on /Users/harukasan/opt/iojs-1.2.0'
node iojs-v1.2.0 successfully installed on /Users/harukasan/opt/iojs-1.2.0
+ echo 'To use this node, do '\''export PATH=/Users/harukasan/opt/iojs-1.2.0/bin:$PATH'\''.'
To use this node, do 'export PATH=/Users/harukasan/opt/iojs-1.2.0/bin:$PATH'.
$ export PATH=/Users/harukasan/opt/iojs-1.2.0/bin:$PATH
$ node -v
v1.2.0
```