### PR TITLE
node-install failed with status 127 over node v6.0

### DIFF
--- a/node-install
+++ b/node-install
@@ -70,7 +70,7 @@ else
 fi
 mv "$ARCHIVE_DIRNAME" "$LOCATION"
 
-"$LOCATION"/bin/npm install -g node-gyp > /tmp/$USER-node-install-npm.log 2>&1
+PATH="$LOCATION"/bin:$PATH "$LOCATION"/bin/npm install -g node-gyp > /tmp/$USER-node-install-npm.log 2>&1
 if [ $? -ne 0 ]; then
     echo "npm install failed. see log /tmp/$USER-node-install-npm.log"
     exit 2


### PR DESCRIPTION
npm command run by ```/usr/bin/env node```. so new node command should be in PATH