### PR TITLE
Support Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Supports:
 * PHP
 * Python
 * Go
+* Rust
 
 ## How to install
 
@@ -37,6 +38,10 @@ Install Python (ex: 2.7.6)
 Install Go (ex: 1.3.3)
 
     xbuild/go-install 1.3.3 ~/local/go-1.3.3
+
+Install Rust (ex: 1.45.0)
+
+    xbuild/rust-install 1.45.0 ~/local/rust-1.45.0
 
 To update minor version, overwrite simply.
 
@@ -90,6 +95,11 @@ Include installed `bin/` to PATH:
     export GOROOT=$HOME/local/go-1.3.3
     export PATH=$GOROOT/bin:$PATH
     go version
+
+    # rust
+    export RUSTUP_HOME=$HOME/local/rust-1.45.0
+    export PATH=$HOME/.cargo/bin:$PATH
+    rustc --version
 
 ## How to try with Docker
 

--- a/rust-install
+++ b/rust-install
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+while getopts fh OPT
+do
+  case $OPT in
+    "f") FLAG_FORCE="TRUE" ;;
+    "h") FLAG_HELP="TRUE" ;;
+    * ) FLAG_HELP="TRUE" ;;
+  esac
+done
+shift `expr $OPTIND - 1`
+
+CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+TARGET_VERSION="$1"
+RUSTUP_HOME="${2-${RUSTUP_HOME:-$HOME/.rustup}}"
+
+if [ "x"$FLAG_HELP != "x" -o "x$TARGET_VERSION" = "x" ]; then
+  echo "[usage] rust-install [-f] VERSION [location]"
+  echo "  ex: rust-install 1.45.0"
+  echo "  ex: rust-install 1.45.0 ~/local/rust-1.45.0"
+  exit 0
+fi
+
+cd $(dirname $0)
+
+export CARGO_HOME
+export RUSTUP_HOME
+
+if [ "x"$FLAG_FORCE = "x" -a -x "$CARGO_HOME/bin/rustup" ]; then
+  hit="$("$CARGO_HOME"/bin/rustup show | grep "^$TARGET_VERSION")"
+  if [ "x$hit" != "x" ]; then
+    echo "rust $TARGET_VERSION already installed."
+    echo "To do force re-install, use '-f' option"
+    exit 0
+  fi
+fi
+
+echo "Start to install rust $TARGET_VERSION ..."
+
+if [ ! -x "$CARGO_HOME"/bin/rustup ]; then
+  # Install using rustup-init
+  DL_RUSTUP_INIT="https://sh.rustup.rs"
+  
+  curl $DL_RUSTUP_INIT -sSf > /tmp/$USER-rustup-init.sh
+  if [ $? -ne 0 ]; then
+      echo "Failed to download rustup-init.sh from $DL_RUSTUP_INIT."
+      exit 1
+  fi
+
+  sh /tmp/$USER-rustup-init.sh -y --default-toolchain $TARGET_VERSION --profile minimal > /tmp/$USER-rust-install.log 2>&1
+  if [ $? -ne 0 ]; then
+      echo "rustup-init failed. see log: /tmp/$USER-rust-install.log"
+      exit 1
+  fi
+else
+  # Install using rustup
+  if [ "x"$FLAG_FORCE = "x" ]; then
+    "$CARGO_HOME"/bin/rustup toolchain install --profile minimal "$TARGET_VERSION" > /tmp/$USER-rust-install.log 2>&1
+  else
+    "$CARGO_HOME"/bin/rustup toolchain install --profile minimal --force "$TARGET_VERSION" > /tmp/$USER-rust-install.log 2>&1
+  fi
+
+  if [ $? -ne 0 ]; then
+      echo "rustup failed. see log: /tmp/$USER-rust-install.log"
+      exit 1
+  fi
+fi
+
+echo "rust $TARGET_VERSION successfully installed on $RUSTUP_HOME"
+echo "To use this rust, do 'export PATH=$CARGO_HOME/bin:\$PATH' and 'export RUSTUP_HOME=$RUSTUP_HOME'."
+echo "If you want to use this rust as default toolchain, you should also do 'rustup default $TARGET_VERSION'"


### PR DESCRIPTION
## Description

This PR adds support for Rust programming language.

Due to version management mechanism of Rust, this script allows installing multiple versions for a single directory. Second argument (installation directory for rustup) is for the compatibility with another languages.

## Example

```console
$ rust-install -h
[usage] rust-install [-f] VERSION [location]
  ex: rust-install 1.45.0
  ex: rust-install 1.45.0 ~/local/rust-1.45.0
$ rust-install 1.45.0 ~/local/rust-1.45.0
Start to install rust 1.45.0 ...
rust 1.45.0 successfully installed on /home/xbuild/local/rust-1.45.0
To use this rust, do 'export PATH=/home/xbuild/.cargo/bin:$PATH' and 'export RUSTUP_HOME=/home/xbuild/local/rust-1.45.0'.
$ export PATH="/home/xbuild/.cargo/bin:$PATH"
$ export RUSTUP_HOME=/home/xbuild/local/rust-1.45.0
$ rustc --version
rustc 1.45.0 (5c1f21c3b 2020-07-13)
$ rust-install 1.45.0 ~/local/rust-1.45.0
rust 1.45.0 already installed.
To do force re-install, use '-f' option
$ rust-install -f 1.45.0 ~/local/rust-1.45.0
Start to install rust 1.45.0 ...
rust 1.45.0 successfully installed on /home/xbuild/local/rust-1.45.0
To use this rust, do 'export PATH=/home/xbuild/.cargo/bin:$PATH' and 'export RUSTUP_HOME=/home/xbuild/local/rust-1.45.0'.
```