### PR TITLE
update pyenv url

### DIFF
--- a/python-install
+++ b/python-install
@@ -27,7 +27,7 @@ if [ ! -d ./var/python-build ]; then
         set -e
         mkdir -p var
         cd var
-        git clone -q https://github.com/yyuu/pyenv.git pyenv-repo
+        git clone -q https://github.com/pyenv/pyenv.git pyenv-repo
         cd pyenv-repo/plugins/python-build
         PREFIX="$XBUILD_PATH"/var/python-build ./install.sh >/dev/null 2>&1
     )


### PR DESCRIPTION
pyenv is currently hosted at https://github.com/pyenv/pyenv rather than https://github.com/yyuu/pyenv

Please update the url to avoid confusion.