### PR TITLE
node-install: select linux-arm64 architecture on aarch64

### DIFF
--- a/node-install
+++ b/node-install
@@ -18,7 +18,7 @@ if [ "x"$FLAG_HELP != "x" -o "x$LOCATION" = "x" ]; then
     echo "[usage] node-install [-f] VERSION LOCATION [arch]"
     echo "  ex: node-install v0.10.26 ~/local/node-v0.10"
     echo "  ex: node-install v0.10.26 ~/local/node-v0.10 darwin-x86"
-    echo "  default arch is 'linux-x64'"
+    echo "  default arch is 'linux-x64' or 'linux-arm64' based on \$(arch)"
     echo ""
     echo "  for io.js:"
     echo "  ex: node-install iojs-v1.2.0 ~/local/iojs-v.1.2.0"
@@ -28,7 +28,11 @@ if [ "x"$FLAG_HELP != "x" -o "x$LOCATION" = "x" ]; then
 fi
 
 if [ "x$ARCH" = "x" ]; then
-    ARCH="linux-x64"
+    if [ "x$(arch)" = "xaarch64" ]; then
+        ARCH="linux-arm64"
+    else
+        ARCH="linux-x64"
+    fi
 fi
 
 cd $(dirname $0)


### PR DESCRIPTION
Previously `node-install` uses `linux-x64` architecture by default.
This PR changes the default architecture of node to `linux-arm64` based on the `$(arch)`.
This is useful for using this script in Dockerfile, especially for M1 mac users.
On building a Docker image including node installation step using the script, it fails
(`/lib64/ld-linux-x86-64.so.2: No such file or directory`) on `node-gyp` installation when the architecture mismatch happens.
This is hard to debug and confusing for all the projects with M1 mac devs, so changing to the comfortable defaults.
Closes #25.
